### PR TITLE
Fix sed behavior in macOS

### DIFF
--- a/pdf2rmnotebook.sh
+++ b/pdf2rmnotebook.sh
@@ -185,7 +185,12 @@ done
 
 
 cat ${VARLIB}/UUID_TAIL.content >> ${NB}/${UUID_N}.content
-sed -i "s/%PAGENUM%/${_page}/" ${NB}/${UUID_N}.content
+# sed in macOS need "backup file" argument
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/%PAGENUM%/${_page}/" ${NB}/${UUID_N}.content
+else
+    sed -i "s/%PAGENUM%/${_page}/" ${NB}/${UUID_N}.content
+fi
 #DEBUG  cat ${NB}/${UUID_N}.content
 
 (


### PR DESCRIPTION
In macOS, sed behaves differently. As described [here](https://stackoverflow.com/questions/7573368/in-place-edits-with-sed-on-os-x), it requires the user to specify the backup file. I added a line that detects running OS and uses alternate sed command if it's running on a Mac.

```bash
# sed in macOS needs "backup file" argument
if [[ "$OSTYPE" == "darwin"* ]]; then
    sed -i '' "s/%PAGENUM%/${_page}/" ${NB}/${UUID_N}.content
else
    sed -i "s/%PAGENUM%/${_page}/" ${NB}/${UUID_N}.content
fi
```