### PR TITLE
Fix duplicate pages on MacOS by converting UUID to lowercase

### DIFF
--- a/pdf2rmnotebook.sh
+++ b/pdf2rmnotebook.sh
@@ -291,7 +291,7 @@ NB=${tempDir}/Notebook
 mkdir ${NB}
 
 _page=0
-UUID_NB=$(uuidgen)   # UUID for Notebook
+UUID_NB=$(uuidgen | tr '[:upper:]' '[:lower:]')   # UUID for Notebook
 
 mkdir ${NB}/${UUID_NB}
 #cp ${VARLIB}/UUID.pagedata ${NB}/${UUID_NB}.pagedata
@@ -341,7 +341,7 @@ do
           ;;
       esac
 
-      UUID_P=$(uuidgen)   # Notebook Pages should be named using the UUID from .content file
+      UUID_P=$(uuidgen | tr '[:upper:]' '[:lower:]')   # Notebook Pages should be named using the UUID from .content file
   #  rmapi interface to reMarkable cloud renames pages from UUID to page number while up/downloading
   #  so we need to use the same convention in naming pages: 0.rm 1.rm ... instead of UUIDs
   #  which are used internally in the rM (see ~/.local/share/remarkable/xochitl/ )


### PR DESCRIPTION
#18 brought up the bug with duplicate pages. However, the fix provided with the json file did not seem to fix this issue for me on macOS. I looked through `~/.local/share/remarkable/xochitl/ ` to find the problem.

**Root Cause**
macOS `uuidgen` defaults to UPPERCASE (e.g., B758D1CD-5FB1-...), while reMarkable firmware 3.x+ expects lowercase UUIDs for notebooks.

**Fix**
Convert UUIDs to lowercase to match reMarkable's native format.

**Tested On**
- Device: reMarkable 2
- Firmware: 20251130114409 (Nov 30th, 2025)
- Platform: macOS

**Example:**
```                                         
  {                                                                                                                                         
  "pages": [                                                                                                                                
      "B758D1CD-5FB1-4744-A4F6-CBBFA2D63F5E",  // Original uppercase from macOS                                                             
      "b758d1cd-5fb1-4744-a4f6-cbbfa2d63f5e"   // Lowercase duplicate added by xochitl                                                 
  ]  
  ```